### PR TITLE
Implement frame rate.

### DIFF
--- a/src/private/private_impl.cpp
+++ b/src/private/private_impl.cpp
@@ -669,6 +669,9 @@ namespace raspicam {
             if ( isOpened() ) commitFlips();
         }
 
+        void Private_Impl::setFrameRate ( int frames_per_second ) {
+            State.framerate = frames_per_second;
+        }
 
         MMAL_PARAM_EXPOSUREMETERINGMODE_T Private_Impl::convertMetering ( RASPICAM_METERING metering ) {
             switch ( metering ) {

--- a/src/private/private_impl.h
+++ b/src/private/private_impl.h
@@ -150,6 +150,7 @@ namespace raspicam {
               *There is currently an upper limit of approximately 330000us (330ms, 0.33s) past which operation is undefined.
               */
             void setShutterSpeed ( unsigned int shutter ); //currently not  supported
+            void setFrameRate ( int fps );
 
             RASPICAM_FORMAT  getFormat() const {return State.captureFtm;}
             //Accessors
@@ -201,6 +202,11 @@ namespace raspicam {
             float getAWBG_red(){return State.awbg_red;}
 
             float getAWBG_blue(){return State.awbg_blue;}
+
+            int getFrameRate() const
+            {
+                return State.framerate;
+            }
 
             RASPICAM_IMAGE_EFFECT getImageEffect() const
             {

--- a/src/raspicam.cpp
+++ b/src/raspicam.cpp
@@ -134,6 +134,9 @@ namespace raspicam {
     void RaspiCam::setVerticalFlip ( bool vFlip ) {
         _impl->setVerticalFlip ( vFlip );
     }
+    void RaspiCam::setFrameRate ( int frames_per_second ) {
+        _impl->setFrameRate ( frames_per_second );
+    }
 
     
     RASPICAM_FORMAT RaspiCam::getFormat()const{return _impl->getFormat( ); }
@@ -154,6 +157,7 @@ namespace raspicam {
 
     RASPICAM_IMAGE_EFFECT RaspiCam::getImageEffect() const{return _impl->getImageEffect() ;};
     RASPICAM_METERING RaspiCam::getMetering() const{return _impl->getMetering() ;}
+    int RaspiCam::getFrameRate() const{return _impl->getFrameRate() ;}
     bool RaspiCam::isHorizontallyFlipped() const {return _impl->isHorizontallyFlipped()  ;}
     bool RaspiCam::isVerticallyFlipped() const {return _impl->isVerticallyFlipped() ;}
 

--- a/src/raspicam.h
+++ b/src/raspicam.h
@@ -138,6 +138,7 @@ namespace raspicam {
         void setMetering ( RASPICAM_METERING metering );
         void setHorizontalFlip ( bool hFlip );
         void setVerticalFlip ( bool vFlip );
+        void setFrameRate ( int frames_per_second );
 
         //Accessors
         RASPICAM_FORMAT getFormat() const;
@@ -156,6 +157,7 @@ namespace raspicam {
         float getAWBG_blue()const;
         RASPICAM_IMAGE_EFFECT getImageEffect() const ;
         RASPICAM_METERING getMetering() const;
+        int getFrameRate() const;
         bool isHorizontallyFlipped() const ;
         bool isVerticallyFlipped() const ;
 

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -94,7 +94,7 @@ namespace raspicam {
         case CV_CAP_PROP_FRAME_HEIGHT :
             return _impl->getHeight();
         case CV_CAP_PROP_FPS:
-            return 30;
+            return _impl->getFrameRate();
         case CV_CAP_PROP_FORMAT :
             return imgFormat;
         case CV_CAP_PROP_MODE :
@@ -171,6 +171,8 @@ namespace raspicam {
         case CV_CAP_PROP_CONVERT_RGB :
             imgFormat=CV_8UC3;
             break;
+        case CV_CAP_PROP_FPS:
+            _impl->setFrameRate ( value );
         default :
             return false;
         };

--- a/utils/raspicam_cv_test.cpp
+++ b/utils/raspicam_cv_test.cpp
@@ -71,6 +71,7 @@ void processCommandLine ( int argc,char **argv,raspicam::RaspiCam_Cv &Camera ) {
     Camera.set ( CV_CAP_PROP_CONTRAST ,getParamVal ( "-co",argc,argv,50 ) );
     Camera.set ( CV_CAP_PROP_SATURATION, getParamVal ( "-sa",argc,argv,50 ) );
     Camera.set ( CV_CAP_PROP_GAIN, getParamVal ( "-g",argc,argv ,50 ) );
+    Camera.set ( CV_CAP_PROP_FPS, getParamVal ( "-fps",argc,argv, 0 ) );
     if ( findParam ( "-gr",argc,argv ) !=-1 )
         Camera.set ( CV_CAP_PROP_FORMAT, CV_8UC1 );
     if ( findParam ( "-test_speed",argc,argv ) !=-1 )
@@ -95,6 +96,8 @@ void showUsage() {
     cout<<"[-co contrast_val (0 to 100)]\n[-sa saturation_val (0 to 100)]";
     cout<<"[-g gain_val  (0 to 100)]\n";
     cout<<"[-ss shutter_speed (0 to 100) 0 auto]\n";
+    cout<<"[-fps frame_rate (0 to 120) 0 auto]\n";
+    cout<<"[-nframes val: number of frames captured (100 default). 0 == Infinite lopp]\n";
 
     cout<<endl;
 }
@@ -120,12 +123,12 @@ int main ( int argc,char **argv ) {
     cout<<"Connected to camera ="<<Camera.getId() <<endl;
 
     cv::Mat image;
-    int nCount=100;
+    int nCount=getParamVal ( "-nframes",argc,argv, 100 );
     cout<<"Capturing"<<endl;
 
     double time_=cv::getTickCount();
 
-    for ( int i=0; i<nCount; i++ ) {
+    for ( int i=0; i<nCount || nCount==0; i++ ) {
         Camera.grab();
         Camera.retrieve ( image );
         if ( !doTestSpeedOnly ) {

--- a/utils/raspicam_test.cpp
+++ b/utils/raspicam_test.cpp
@@ -122,7 +122,7 @@ void processCommandLine ( int argc,char **argv,raspicam::RaspiCam &Camera ) {
         Camera.setAWB( getAwbFromString ( argv[idx+1] ) );
     nFramesCaptured=getParamVal("-nframes",argc,argv,100);
     Camera.setAWB_RB(getParamVal("-awb_b",argc,argv ,1), getParamVal("-awb_g",argc,argv ,1));
-
+    Camera.setFrameRate(getParamVal("-fps",argc,argv, 0));
 }
 void showUsage() {
     cout<<"Usage: "<<endl;
@@ -139,6 +139,7 @@ void showUsage() {
     cout<<"[-nframes val: number of frames captured (100 default). 0 == Infinite lopp]\n";
     cout<<"[-awb_r val:(0,8):set the value for the red component of white balance]"<<endl;
     cout<<"[-awb_g val:(0,8):set the value for the green component of white balance]"<<endl;
+    cout<<"[-fps frame_rate (0 to 120) 0 auto]\n";
 
     cout<<endl;
 }


### PR DESCRIPTION
This allows higher frame rate video capture to be requested. Notably, 640x480 can be captured at 90Hz and 320x240 can be captured at 120Hz (on the v2 camera). Changing the requested frame rate will influence the video capture mode. This causes different binning and cropping parameters to be applied. Some information about the available modes are at: http://picamera.readthedocs.io/en/release-1.10/fov.html#camera-modes

fixes #5