### PR TITLE
Don't set format to RASPICAM_FORMAT_BGR

### DIFF
--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -140,7 +140,7 @@ namespace raspicam {
                 imgFormat=value;
             }
             else if (value==CV_8UC3){
-                _impl->setFormat(RASPICAM_FORMAT_BGR);
+                _impl->setFormat(RASPICAM_FORMAT_RGB);
                 imgFormat=value;
             }
             else res=false;//error int format


### PR DESCRIPTION
When using Kerberos.io with my Raspicam, red and blue were switched in all captures. I'm probably missing something but changing the format fixed it for me. 