### PR TITLE
Fix blue images

### DIFF
--- a/dependencies/mmal/util/mmal_util.h
+++ b/dependencies/mmal/util/mmal_util.h
@@ -164,6 +164,17 @@ MMAL_PORT_T *mmal_util_get_port(MMAL_COMPONENT_T *comp, MMAL_PORT_TYPE_T type, u
 char *mmal_4cc_to_string(char *buf, size_t len, uint32_t fourcc);
 
 
+/** On FW prior to June 2016, camera and video_splitter
+ *  had BGR24 and RGB24 support reversed.
+ *  This is now fixed, and this function will return whether the
+ *  FW has the fix or not.
+ *
+ * @param port   MMAL port to check (on camera or video_splitter)
+ * @return 0 if old firmware, 1 if new.
+ *
+ */
+int mmal_util_rgb_order_fixed(MMAL_PORT_T *port);
+
 #ifdef __cplusplus
 }
 #endif

--- a/simpletest_raspicam/CMakeLists.txt
+++ b/simpletest_raspicam/CMakeLists.txt
@@ -1,0 +1,8 @@
+#####################################
+cmake_minimum_required (VERSION 2.8) 
+project (raspicam_test)
+find_package(raspicam REQUIRED)
+add_executable (simpletest_raspicam simpletest_raspicam.cpp)  
+target_link_libraries (simpletest_raspicam ${raspicam_LIBS})
+#####################################
+

--- a/simpletest_raspicam/simpletest_raspicam.cpp
+++ b/simpletest_raspicam/simpletest_raspicam.cpp
@@ -1,0 +1,34 @@
+
+/**
+*/
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <unistd.h>
+#include <raspicam/raspicam.h>
+using namespace std;
+
+int main ( int argc,char **argv ) {
+    raspicam::RaspiCam Camera; //Cmaera object
+    //Open camera 
+    cout<<"Opening Camera..."<<endl;
+    if ( !Camera.open()) {cerr<<"Error opening camera"<<endl;return -1;}
+    //wait a while until camera stabilizes
+    cout<<"Sleeping for 3 secs"<<endl;
+    usleep(3*1000000);
+    //capture
+    Camera.grab();
+    //allocate memory
+    unsigned char *data=new unsigned char[  Camera.getImageTypeSize ( raspicam::RASPICAM_FORMAT_RGB )];
+    //extract the image in rgb format
+    Camera.retrieve ( data,raspicam::RASPICAM_FORMAT_RGB );//get camera image
+    //save
+    std::ofstream outFile ( "raspicam_image.ppm",std::ios::binary );
+    outFile<<"P6\n"<<Camera.getWidth() <<" "<<Camera.getHeight() <<" 255\n";
+    outFile.write ( ( char* ) data, Camera.getImageTypeSize ( raspicam::RASPICAM_FORMAT_RGB ) );
+    cout<<"Image saved at raspicam_image.ppm"<<endl;
+    //free resrources    
+    delete data;
+    return 0;
+}
+//

--- a/src/private/fake_mmal_dependencies.cpp
+++ b/src/private/fake_mmal_dependencies.cpp
@@ -396,3 +396,5 @@ void mmal_buffer_header_release(MMAL_BUFFER_HEADER_T *header){UNUSED(header);}
  * @return length (in elements) of the queue.
  */
 unsigned int mmal_queue_length(MMAL_QUEUE_T *queue){UNUSED(queue);return 0;}
+
+int mmal_util_rgb_order_fixed(MMAL_PORT_T *port) {}

--- a/src/private/private_impl.cpp
+++ b/src/private/private_impl.cpp
@@ -261,6 +261,8 @@ namespace raspicam {
                 cerr << __func__ << ": Failed to set sensmode.";
             }
 
+            _rgb_bgr_fixed = !!(mmal_util_rgb_order_fixed(video_port));
+
             //  set up the camera configuration
 
             MMAL_PARAMETER_CAMERA_CONFIG_T cam_config;
@@ -814,9 +816,9 @@ namespace raspicam {
         int Private_Impl::convertFormat ( RASPICAM_FORMAT fmt ) {
             switch ( fmt ) {
             case RASPICAM_FORMAT_RGB:
-                return MMAL_ENCODING_RGB24;
+                return _rgb_bgr_fixed ? MMAL_ENCODING_RGB24 : MMAL_ENCODING_BGR24;
             case RASPICAM_FORMAT_BGR:
-                return MMAL_ENCODING_BGR24;
+                return _rgb_bgr_fixed ? MMAL_ENCODING_BGR24 : MMAL_ENCODING_RGB24;
             case RASPICAM_FORMAT_GRAY:
                 return MMAL_ENCODING_I420;
             case RASPICAM_FORMAT_YUV420:

--- a/src/private/private_impl.h
+++ b/src/private/private_impl.h
@@ -284,6 +284,8 @@ namespace raspicam {
             bool _isOpened;
             bool _isCapturing;
 
+            bool _rgb_bgr_fixed;
+
 
         };
     };

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -140,7 +140,7 @@ namespace raspicam {
                 imgFormat=value;
             }
             else if (value==CV_8UC3){
-                _impl->setFormat(RASPICAM_FORMAT_BGR);
+                _impl->setFormat(RASPICAM_FORMAT_RGB);
                 imgFormat=value;
             }
             else res=false;//error int format


### PR DESCRIPTION
This is a pull request which includes all the changes from @6by9 including using `mmal_util_rgb_order_fixed` to test camera firmware version to determine whether the blue/red have been switched. 

Unfortunately it requires a newer version of `mmal` and I wasn't sure of the best way to update that dependancy.