### PR TITLE
Update README to fix cmake and sleep errors

### DIFF
--- a/README
+++ b/README
@@ -103,7 +103,7 @@ int main ( int argc,char **argv ) {
     if ( !Camera.open()) {cerr<<"Error opening camera"<<endl;return -1;}
     //wait a while until camera stabilizes
     cout<<"Sleeping for 3 secs"<<endl;
-    usleep(3);
+    usleep(3e6);
     //capture
     Camera.grab();
     //allocate memory

--- a/README
+++ b/README
@@ -89,6 +89,7 @@ First create a file with the name simpletest_raspicam.cpp and add the following 
 
 /**
 */
+#include <unistd.h>
 #include <ctime>
 #include <fstream>
 #include <iostream>
@@ -102,7 +103,7 @@ int main ( int argc,char **argv ) {
     if ( !Camera.open()) {cerr<<"Error opening camera"<<endl;return -1;}
     //wait a while until camera stabilizes
     cout<<"Sleeping for 3 secs"<<endl;
-    sleep(3);
+    usleep(3);
     //capture
     Camera.grab();
     //allocate memory
@@ -124,6 +125,7 @@ Now, create a file named CMakeLists.txt and add:
 #####################################
 cmake_minimum_required (VERSION 2.8) 
 project (raspicam_test)
+set(CMAKE_MODULE_PATH "/usr/local/lib/cmake/${CMAKE_MODULE_PATH}")
 find_package(raspicam REQUIRED)
 add_executable (simpletest_raspicam simpletest_raspicam.cpp)  
 target_link_libraries (simpletest_raspicam ${raspicam_LIBS})


### PR DESCRIPTION
Sleep function was not defined with provided headers, switched to usleep from unistd.h.

Added a line in CMakeLists.txt to find the raspicam libraries properly from any directory after "make install"

This now works as expected
