### PR TITLE
Feature/camera selection (extended)

### DIFF
--- a/src/private/private_impl.cpp
+++ b/src/private/private_impl.cpp
@@ -254,7 +254,7 @@ namespace raspicam {
 
             if (status != MMAL_SUCCESS)
             {
-                cerr<< ( "Failed to select camera" );
+                cerr << "Could not select camera " << getCameraNum() << '\n';
                 return 0;
             }
 

--- a/src/private_still/private_still_impl.cpp
+++ b/src/private_still/private_still_impl.cpp
@@ -210,6 +210,17 @@ namespace raspicam {
             }
 
             camera_still_port = camera->output[MMAL_CAMERA_CAPTURE_PORT];
+			
+			MMAL_PARAMETER_INT32_T camera_num = {
+				{MMAL_PARAMETER_CAMERA_NUM, sizeof ( camera_num ) },
+				getCameraNum()
+			};
+			if (mmal_port_parameter_set ( camera->control, &camera_num.hdr) != MMAL_SUCCESS )
+			{
+                cerr << "Could not select camera " << getCameraNum() << '\n';
+                destroyCamera();
+                return 0;
+			}
 
             // Enable the camera, and tell it its control callback function
             if ( mmal_port_enable ( camera->control, control_callback ) ) {
@@ -332,8 +343,9 @@ namespace raspicam {
             }
         }
 
-        int Private_Impl_Still::initialize() {
+        int Private_Impl_Still::initialize( int cameraNumber ) {
             if ( _isInitialized ) return 0;
+			setCameraNum( cameraNumber );
             if ( createCamera() ) {
                 cout << API_NAME << ": Failed to create camera component.\n";
                 destroyCamera();
@@ -454,6 +466,10 @@ namespace raspicam {
             setHeight ( height );
         }
 
+        void Private_Impl_Still::setCameraNum  ( int cameraNumber ) {
+            cameraNum = cameraNumber;
+        }
+
         void Private_Impl_Still::setBrightness ( unsigned int brightness ) {
             if ( brightness > 100 )
                 brightness = brightness % 100;
@@ -556,6 +572,10 @@ namespace raspicam {
 
         unsigned int Private_Impl_Still::getQuality() {
             return quality;
+        }
+
+        int Private_Impl_Still::getCameraNum() {
+            return cameraNum;
         }
 
         int Private_Impl_Still::getISO() {

--- a/src/private_still/private_still_impl.h
+++ b/src/private_still/private_still_impl.h
@@ -65,6 +65,7 @@ namespace raspicam {
             unsigned int rotation; // 0 to 359
             unsigned int brightness; // 0 to 100
             unsigned int quality; // 0 to 100
+            int cameraNum; // 0 or 1
             int iso;
             int sharpness; // -100 to 100
             int contrast; // -100 to 100
@@ -118,7 +119,7 @@ namespace raspicam {
                 encoder_output_port = NULL;
 		_isInitialized=false;
             }
-            int initialize();
+            int initialize( int cameraNumber=0 );
             int startCapture ( imageTakenCallback userCallback, unsigned char * preallocated_data, unsigned int offset, unsigned int length );
             void stopCapture();
             bool takePicture ( unsigned char * preallocated_data, unsigned int length );
@@ -143,12 +144,14 @@ namespace raspicam {
             void setMetering ( RASPICAM_METERING metering );
             void setHorizontalFlip ( bool hFlip );
             void setVerticalFlip ( bool vFlip );
+			void setCameraNum ( int cameraNumber );
 
             unsigned int getWidth();
             unsigned int getHeight();
             unsigned int getBrightness();
             unsigned int getRotation();
             unsigned int getQuality();
+			int getCameraNum();
             int getISO();
             int getSharpness();
             int getContrast();

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -52,12 +52,18 @@ namespace raspicam {
 
     /** Open  capturing device for video capturing
      */
-    bool RaspiCam_Cv::open ( void ) {
-        return _impl->open();
+    bool RaspiCam_Cv::open ( bool StartCapture, int cameraNumber ) {
+        return _impl->open ( StartCapture, cameraNumber );
     }
     /**
      * Returns true if video capturing has been initialized already.
      */
+    bool RaspiCam_Cv::startCapture() {
+        return _impl->startCapture();
+    }
+	/**
+	 * Returns true if video capturing has been initialized already.
+	 */
     bool RaspiCam_Cv::isOpened() const {return _impl->isOpened();}
     /**
     *Closes video file or capturing device.

--- a/src/raspicam_cv.h
+++ b/src/raspicam_cv.h
@@ -57,7 +57,10 @@ namespace raspicam {
         ~RaspiCam_Cv();
         /** Open  capturing device for video capturing
          */
-        bool open ( void );
+        bool open ( bool StartCapture=true, int cameraNumber=0 );
+        /**Makes camera start capturing
+         */
+        bool startCapture();
         /**
          * Returns true if video capturing has been initialized already.
          */

--- a/src/raspicam_still.cpp
+++ b/src/raspicam_still.cpp
@@ -46,8 +46,8 @@ namespace raspicam {
     }
 
 
-    bool RaspiCam_Still::open ( ) {
-        return _impl->initialize() ==0;
+    bool RaspiCam_Still::open ( int cameraNumber ) {
+        return _impl->initialize( cameraNumber ) ==0;
     }
     bool RaspiCam_Still::grab_retrieve ( unsigned char * preallocated_data, unsigned int length ) {
         return _impl->takePicture ( preallocated_data, length );

--- a/src/raspicam_still.h
+++ b/src/raspicam_still.h
@@ -58,7 +58,7 @@ namespace raspicam {
         //Destructor
         ~RaspiCam_Still();
         // Opens camera connection
-        bool open ( );
+        bool open ( int cameraNumber=0 );
         //Grabs and set the data into the data buffer which has the indicated length. It is your responsability
         // to alloc the buffer. You can use getImageBufferSize for that matter.
         bool grab_retrieve ( unsigned char * data, unsigned int length );

--- a/src/raspicam_still_cv.cpp
+++ b/src/raspicam_still_cv.cpp
@@ -54,8 +54,8 @@ namespace raspicam {
     }
 
 
-    bool RaspiCam_Still_Cv::open ( ) {
-        _isOpened= _impl->initialize() ==0;
+    bool RaspiCam_Still_Cv::open ( int cameraNumber ) {
+        _isOpened= _impl->initialize( cameraNumber ) ==0;
         return _isOpened;
     }
 

--- a/src/raspicam_still_cv.h
+++ b/src/raspicam_still_cv.h
@@ -62,7 +62,7 @@ namespace raspicam {
         ~RaspiCam_Still_Cv();
         /** Open  capturing device for video capturing
          */
-        bool open ( void );
+        bool open ( int cameraNumber=0 );
         /**
          * Returns true if video capturing has been initialized already.
          */


### PR DESCRIPTION
* Replicated sp3c1's addition of camera selection feature to raspicam_cv (#19)
   * Added startCapture feature similar to raspicam

* Added similar implementation for camera selection to raspicam_still and raspicam_still_cv

* Changed cerr for failed camera selection to be uniform with still implementation