### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#RaspiCam: C++ API for using Raspberry camera (with OpenCV)
+# RaspiCam: C++ API for using Raspberry camera (with OpenCV)
 
 This library allows to use the Raspberry Pi Camera under BSD License. 
 
@@ -7,7 +7,7 @@ on this GIT repository by Cédric Verstraeten. Please note that is NOT the OFFIC
 
 This repository is used in the [Kerberos.io](https://github.com/kerberos-io) project.
 
-##Release notes
+## Release notes
 
 Update 2014/03/04: version 0.1.1 released Download at SourceForge
 Main feaure in 0.0.7 : Still camera API. You can now use the still mode for high resolution (includes OpenCv interface). See examples for more info.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
