### PR TITLE
Fix misaligned image sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ RGB Mode
 BGR Mode
    - 1280x960: 14 fps,  640x480 : 29.29fps,  320x240 : 29.24fps
  
+Note: when using the full resolution video callbacks with the full resolution of the Raspberry Pi Camera v2, you will likely get an error such as `mmal: mmal_vc_port_enable: failed to enable port vc.ril.camera:out:1(BGR3): ENOSPC`. In order to fix this increase your GPU memory to at least 256MB.
+
 Color conversion is the most time consuming part. We still need to improve that part. Go to src/private and check if you can contribute!
  
 Note: the library is compiled with the options: -Wall -ffunction-sections  -fomit-frame-pointer -O2 -ffast-math -DNDEBUG -mcpu=arm1176jzf-s  -mfpu=vfp -mfloat-abi=hard -ftree-vectorize

--- a/src/private/private_impl.h
+++ b/src/private/private_impl.h
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mutex>
 #include <string>
 #include "raspicamtypes.h"
-#include "private_types.h" 
+#include "private_types.h"
 #include "threadcondition.h"
 namespace raspicam {
     namespace _private
@@ -73,6 +73,7 @@ namespace raspicam {
 
 
                 RASPIVID_STATE *pstate;            /// pointer to our state in case required in callback
+                Private_Impl *inst;
                 std::mutex _mutex;
                 ThreadCondition Thcond;
                 bool wantToGrab;
@@ -304,5 +305,3 @@ namespace raspicam {
 };
 
 #endif
-
-

--- a/src/raspicam.cpp
+++ b/src/raspicam.cpp
@@ -141,8 +141,12 @@ namespace raspicam {
     void RaspiCam::setFrameRate ( int frames_per_second ) {
         _impl->setFrameRate ( frames_per_second );
     }
+    void RaspiCam::setSensorMode ( int mode ) {
+        _impl->setSensorMode ( mode );
+    }
 
-    
+
+
     RASPICAM_FORMAT RaspiCam::getFormat()const{return _impl->getFormat( ); }
     unsigned int RaspiCam::getWidth() const{return _impl->getWidth() ;}
     unsigned int RaspiCam::getHeight() const{return _impl->getHeight()  ;}
@@ -171,4 +175,3 @@ namespace raspicam {
 
 
 };
-

--- a/src/raspicam.h
+++ b/src/raspicam.h
@@ -146,6 +146,7 @@ namespace raspicam {
         void setHorizontalFlip ( bool hFlip );
         void setVerticalFlip ( bool vFlip );
         void setFrameRate ( int frames_per_second );
+        void setSensorMode ( int mode );
 
         //Accessors
         RASPICAM_FORMAT getFormat() const;
@@ -184,4 +185,3 @@ namespace raspicam {
     };
 };
 #endif
-

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Run this script to test the library's functionality of various formats and sizes
+OPTS=""
+
+func () {
+	f=$1_$2x$3
+	mkdir -p "$f"; cd "$f"
+	../../build/utils/raspicam_test $OPTS -$1 -w $2 -h $3
+	cd ..
+}
+
+func2 () {
+	func $1 3280 2464
+	func $1 1640 1232
+	func $1 1280 720
+}
+
+
+mkdir -p out; cd out
+
+func2 rgb
+func2 yuv
+func2 gr
+
+cd ..


### PR DESCRIPTION
- Can set sensor mode for public api
- Image sizes not aligned to 32x16 are supported by padding up while copying the image
- Changed tester output to .yuv as this format is more readable than P7

I've tested this across a few resolutions and all the supported raw formats with the included script.

Fixes #21