### PR TITLE
Remove -Werror compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ IF(${CMAKE_SYSTEM_PROCESSOR} MATCHES armv6l ) ##BEAGLE BOARD
   SET(EXTRA_C_FLAGS_RELEASE "${EXTRA_C_FLAGS_RELEASE} -mcpu=arm1176jzf-s  -mfpu=vfp -mfloat-abi=hard -ftree-vectorize")  
 ENDIF()
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pedantic -Werror -Wall -Wno-variadic-macros -std=c++0x -Wl,--no-as-needed")#for using condition variables
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pedantic -Wall -Wno-variadic-macros -std=c++0x -Wl,--no-as-needed")#for using condition variables
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_C_FLAGS} ")
 SET(CMAKE_CXX_FLAGS_RELEASE "${EXTRA_C_FLAGS_RELEASE}  -lpthread")
 SET(CMAKE_CXX_FLAGS_DEBUG "${EXTRA_C_FLAGS_DEBUG}  -lpthread")


### PR DESCRIPTION
In the latest version of GCC there is a depreciation warning, which prevents compilation from succeeding (dynamic exception specifications are deprecated in C++11). In order for the project to compile, the -Werror flag musn't be set.

I was compiling this library on my RPi running Arch Linux ARM with GCC 7.2.1 and got a compilation error.
````c++
❯ make
[  4%] Building CXX object src/CMakeFiles/raspicam.dir/raspicam.cpp.o
In file included from /home/protecto/raspicam/src/private/private_impl.h:46:0,
                 from /home/protecto/raspicam/src/raspicam.cpp:39:
/home/protecto/raspicam/src/private/threadcondition.h:57:31: error: dynamic exception specifications are deprecated in C++11 [-Werror=deprecated]
             ThreadCondition() throw ( raspicam::Exception );
                               ^~~~~
/home/protecto/raspicam/src/private/threadcondition.h:60:58: error: dynamic exception specifications are deprecated in C++11 [-Werror=deprecated]
             void Wait(std::unique_lock<std::mutex>& lck) throw ( raspicam::Exception );
                                                          ^~~~~
/home/protecto/raspicam/src/private/threadcondition.h:64:30: error: dynamic exception specifications are deprecated in C++11 [-Werror=deprecated]
             void BroadCast() throw ( raspicam::Exception );
                              ^~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [src/CMakeFiles/raspicam.dir/build.make:63: src/CMakeFiles/raspicam.dir/raspicam.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:120: src/CMakeFiles/raspicam.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
````

In order for this library to compile I had to remove the -Werror flag. After removing it, compilation succeeded. I decided to create a pull request, because more people might be having this issue.

It doesn't affect Raspbian (older GCC).