### PR TITLE
Update raspicam to support OpenCV3 and above

### DIFF
--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace raspicam {
     RaspiCam_Cv::RaspiCam_Cv() {
         _impl=new _private::Private_Impl();
-	set(CV_CAP_PROP_FORMAT,CV_8UC3);
+	set(cv::CAP_PROP_FORMAT,CV_8UC3);
  
     }
     RaspiCam_Cv::~RaspiCam_Cv() {
@@ -92,26 +92,26 @@ namespace raspicam {
     double RaspiCam_Cv::get ( int propId ) {
 
         switch ( propId ) {
-        case CV_CAP_PROP_MODE:
+        case cv::CAP_PROP_MODE:
             return _impl->getSensorMode();
-        case CV_CAP_PROP_FRAME_WIDTH :
+        case cv::CAP_PROP_FRAME_WIDTH :
             return _impl->getWidth();
-        case CV_CAP_PROP_FRAME_HEIGHT :
+        case cv::CAP_PROP_FRAME_HEIGHT :
             return _impl->getHeight();
-        case CV_CAP_PROP_FPS:
+        case cv::CAP_PROP_FPS:
             return _impl->getFrameRate();
-        case CV_CAP_PROP_FORMAT :
+        case cv::CAP_PROP_FORMAT :
             return imgFormat;
-        case CV_CAP_PROP_BRIGHTNESS :
+        case cv::CAP_PROP_BRIGHTNESS :
             return _impl->getBrightness();
-        case CV_CAP_PROP_CONTRAST :
+        case cv::CAP_PROP_CONTRAST :
             return Scaler::scale ( -100,100,0,100,  _impl->getContrast() ); 
-        case CV_CAP_PROP_SATURATION :
+        case cv::CAP_PROP_SATURATION :
             return  Scaler::scale ( -100,100,0,100, _impl->getSaturation() );;
-//     case CV_CAP_PROP_HUE : return _cam_impl->getSharpness();
-        case CV_CAP_PROP_GAIN :
+//     case cv::CAP_PROP_HUE : return _cam_impl->getSharpness();
+        case cv::CAP_PROP_GAIN :
             return  Scaler::scale ( 0,800,0,100, _impl->getISO() );
-        case CV_CAP_PROP_EXPOSURE :
+        case cv::CAP_PROP_EXPOSURE :
             if ( _impl->getShutterSpeed() ==0 )
                 return -1;//auto
             else return Scaler::scale (0,330000, 0,100, _impl->getShutterSpeed() )  ;
@@ -127,17 +127,17 @@ namespace raspicam {
     bool RaspiCam_Cv::set ( int propId, double value ) {
 
         switch ( propId ) {
-        case CV_CAP_PROP_MODE:
+        case cv::CAP_PROP_MODE:
             _impl->setSensorMode(value);
             break;
             
-        case CV_CAP_PROP_FRAME_WIDTH :
+        case cv::CAP_PROP_FRAME_WIDTH :
             _impl->setWidth ( value );
             break;
-        case CV_CAP_PROP_FRAME_HEIGHT :
+        case cv::CAP_PROP_FRAME_HEIGHT :
             _impl->setHeight ( value );
             break;
-        case CV_CAP_PROP_FORMAT :{
+        case cv::CAP_PROP_FORMAT :{
             bool res=true;
             if ( value==CV_8UC1  ){
                 _impl->setFormat(RASPICAM_FORMAT_GRAY);
@@ -150,20 +150,20 @@ namespace raspicam {
             else res=false;//error int format
             return res;
         }break;
-        case CV_CAP_PROP_BRIGHTNESS :
+        case cv::CAP_PROP_BRIGHTNESS :
             _impl->setBrightness ( value );
             break;
-        case CV_CAP_PROP_CONTRAST : 
+        case cv::CAP_PROP_CONTRAST : 
             _impl->setContrast ( Scaler::scale ( 0,100,-100,100, value ) );
             break;
-        case CV_CAP_PROP_SATURATION :
+        case cv::CAP_PROP_SATURATION :
             _impl->setSaturation ( Scaler::scale ( 0,100,-100,100, value ) );
             break;
-//     case CV_CAP_PROP_HUE : return _cam_impl->getSharpness();
-        case CV_CAP_PROP_GAIN :
+//     case cv::CAP_PROP_HUE : return _cam_impl->getSharpness();
+        case cv::CAP_PROP_GAIN :
             _impl->setISO ( Scaler::scale ( 0,100,0,800, value ) );
             break;
-        case CV_CAP_PROP_EXPOSURE :
+        case cv::CAP_PROP_EXPOSURE :
             if ( value>0 && value<=100 ) { 
                 _impl->setShutterSpeed ( Scaler::scale ( 0,100,0,330000, value ) );
             } else {
@@ -171,10 +171,10 @@ namespace raspicam {
                 _impl->setShutterSpeed ( 0 );
             }
             break;
-        case CV_CAP_PROP_CONVERT_RGB :
+        case cv::CAP_PROP_CONVERT_RGB :
             imgFormat=CV_8UC3;
             break;
-        case CV_CAP_PROP_FPS:
+        case cv::CAP_PROP_FPS:
             _impl->setFrameRate ( value );
         default :
             return false;

--- a/src/raspicam_cv.h
+++ b/src/raspicam_cv.h
@@ -92,16 +92,16 @@ namespace raspicam {
 	 * 
 	 * 
 	 * Implemented properties:
-	 * CV_CAP_PROP_FRAME_WIDTH,CV_CAP_PROP_FRAME_HEIGHT,
-	 * CV_CAP_PROP_FORMAT: CV_8UC1 or CV_8UC3
-	 * CV_CAP_PROP_BRIGHTNESS: [0,100]
-	 * CV_CAP_PROP_CONTRAST: [0,100]
-	 * CV_CAP_PROP_SATURATION: [0,100]
-	 * CV_CAP_PROP_GAIN: (iso): [0,100]
-	 * CV_CAP_PROP_EXPOSURE: -1 auto. [1,100] shutter speed from 0 to 33ms
-     * CV_CAP_PROP_WHITE_BALANCE_RED_V : [1,100] -1 auto whitebalance
-     * CV_CAP_PROP_WHITE_BALANCE_BLUE_U : [1,100] -1 auto whitebalance
-     * CV_CAP_PROP_MODE : [1,7] 0 auto mode
+	 * cv::CAP_PROP_FRAME_WIDTH,cv::CAP_PROP_FRAME_HEIGHT,
+	 * cv::CAP_PROP_FORMAT: CV_8UC1 or CV_8UC3
+	 * cv::CAP_PROP_BRIGHTNESS: [0,100]
+	 * cv::CAP_PROP_CONTRAST: [0,100]
+	 * cv::CAP_PROP_SATURATION: [0,100]
+	 * cv::CAP_PROP_GAIN: (iso): [0,100]
+	 * cv::CAP_PROP_EXPOSURE: -1 auto. [1,100] shutter speed from 0 to 33ms
+     * cv::CAP_PROP_WHITE_BALANCE_RED_V : [1,100] -1 auto whitebalance
+     * cv::CAP_PROP_WHITE_BALANCE_BLUE_U : [1,100] -1 auto whitebalance
+     * cv::CAP_PROP_MODE : [1,7] 0 auto mode
      *
          */
 

--- a/src/raspicam_still_cv.cpp
+++ b/src/raspicam_still_cv.cpp
@@ -86,33 +86,33 @@ namespace raspicam {
 
         switch ( propId ) {
 
-        case CV_CAP_PROP_FRAME_WIDTH :
+        case cv::CAP_PROP_FRAME_WIDTH :
             return _impl->getWidth();
-        case CV_CAP_PROP_FRAME_HEIGHT :
+        case cv::CAP_PROP_FRAME_HEIGHT :
             return _impl->getHeight();
-        case CV_CAP_PROP_FPS:
+        case cv::CAP_PROP_FPS:
             return 30;
-        case CV_CAP_PROP_FORMAT :
+        case cv::CAP_PROP_FORMAT :
             return CV_8UC3;
-        case CV_CAP_PROP_MODE :
+        case cv::CAP_PROP_MODE :
             return 0;
-        case CV_CAP_PROP_BRIGHTNESS :
+        case cv::CAP_PROP_BRIGHTNESS :
             return _impl->getBrightness();
-        case CV_CAP_PROP_CONTRAST :
+        case cv::CAP_PROP_CONTRAST :
             return Scaler::scale ( -100,100,0,100,  _impl->getContrast() );
-        case CV_CAP_PROP_SATURATION :
+        case cv::CAP_PROP_SATURATION :
             return  Scaler::scale ( -100,100,0,100, _impl->getSaturation() );;
-//     case CV_CAP_PROP_HUE : return _cam_impl->getSharpness();
-        case CV_CAP_PROP_GAIN :
+//     case cv::CAP_PROP_HUE : return _cam_impl->getSharpness();
+        case cv::CAP_PROP_GAIN :
             return  Scaler::scale ( 0,800,0,100, _impl->getISO() );
-        case CV_CAP_PROP_EXPOSURE :
+        case cv::CAP_PROP_EXPOSURE :
 //             if ( _impl->getShutterSpeed() ==0 )
             return -1;//not yet
 //             else return Scaler::scale (0,330000, 0,100, _impl->getShutterSpeed() )  ;
             break;
-        case CV_CAP_PROP_CONVERT_RGB :
+        case cv::CAP_PROP_CONVERT_RGB :
             return ( true );
-//     case CV_CAP_PROP_WHITE_BALANCE :return _cam_impl->getAWB();
+//     case cv::CAP_PROP_WHITE_BALANCE :return _cam_impl->getAWB();
         default :
             return -1;
         };
@@ -125,41 +125,41 @@ namespace raspicam {
 
         switch ( propId ) {
 
-        case CV_CAP_PROP_FRAME_WIDTH :
+        case cv::CAP_PROP_FRAME_WIDTH :
             if ( value!=_impl->getWidth() ) {
                 delete image_buffer;
                 image_buffer=0;
                 _impl->setWidth ( value );
             }
             break;
-        case CV_CAP_PROP_FRAME_HEIGHT :
+        case cv::CAP_PROP_FRAME_HEIGHT :
             if ( value!=_impl->getHeight() ) {
                 delete image_buffer;
                 image_buffer=0;
                 _impl->setHeight ( value );
             }
             break;
-        case CV_CAP_PROP_FORMAT : {
+        case cv::CAP_PROP_FORMAT : {
             return false;		//ONLY 8UC3 allowed at this moment
         }
         break;
-        case CV_CAP_PROP_MODE ://nothing to  do yet
+        case cv::CAP_PROP_MODE ://nothing to  do yet
             return false;
             break;
-        case CV_CAP_PROP_BRIGHTNESS :
+        case cv::CAP_PROP_BRIGHTNESS :
             _impl->setBrightness ( value );
             break;
-        case CV_CAP_PROP_CONTRAST :
+        case cv::CAP_PROP_CONTRAST :
             _impl->setContrast ( Scaler::scale ( 0,100,-100,100, value ) );
             break;
-        case CV_CAP_PROP_SATURATION :
+        case cv::CAP_PROP_SATURATION :
             _impl->setSaturation ( Scaler::scale ( 0,100,-100,100, value ) );
             break;
-//     case CV_CAP_PROP_HUE : return _cam_impl->getSharpness();
-        case CV_CAP_PROP_GAIN :
+//     case cv::CAP_PROP_HUE : return _cam_impl->getSharpness();
+        case cv::CAP_PROP_GAIN :
             _impl->setISO ( Scaler::scale ( 0,100,0,800, value ) );
             break;
-        case CV_CAP_PROP_EXPOSURE :
+        case cv::CAP_PROP_EXPOSURE :
 //             if ( value>0 && value<=100 ) {
 //                 _impl->setShutterSpeed ( Scaler::scale ( 0,100,0,330000, value ) );
 //             } else {
@@ -167,10 +167,10 @@ namespace raspicam {
 //                 _impl->setShutterSpeed ( 0 );
 //             }
             break;
-        case CV_CAP_PROP_CONVERT_RGB :
+        case cv::CAP_PROP_CONVERT_RGB :
 //              CV_8UC3;
             break;
-//     case CV_CAP_PROP_WHITE_BALANCE :return _cam_impl->getAWB();
+//     case cv::CAP_PROP_WHITE_BALANCE :return _cam_impl->getAWB();
         default :
             return false;
         };

--- a/src/raspicam_still_cv.h
+++ b/src/raspicam_still_cv.h
@@ -91,13 +91,13 @@ namespace raspicam {
         *
          *
          * Implemented properties:
-         * CV_CAP_PROP_FRAME_WIDTH,CV_CAP_PROP_FRAME_HEIGHT,
-         * CV_CAP_PROP_FORMAT: CV_8UC1 or CV_8UC3
-         * CV_CAP_PROP_BRIGHTNESS: [0,100]
-         * CV_CAP_PROP_CONTRAST: [0,100]
-         * CV_CAP_PROP_SATURATION: [0,100]
-         * CV_CAP_PROP_GAIN: (iso): [0,100]
-         * CV_CAP_PROP_EXPOSURE: -1 auto. [1,100] shutter speed from 0 to 33ms
+         * cv::CAP_PROP_FRAME_WIDTH,cv::CAP_PROP_FRAME_HEIGHT,
+         * cv::CAP_PROP_FORMAT: CV_8UC1 or CV_8UC3
+         * cv::CAP_PROP_BRIGHTNESS: [0,100]
+         * cv::CAP_PROP_CONTRAST: [0,100]
+         * cv::CAP_PROP_SATURATION: [0,100]
+         * cv::CAP_PROP_GAIN: (iso): [0,100]
+         * cv::CAP_PROP_EXPOSURE: -1 auto. [1,100] shutter speed from 0 to 33ms
          *
                */
 

--- a/utils/raspicam_cv_still_test.cpp
+++ b/utils/raspicam_cv_still_test.cpp
@@ -64,8 +64,8 @@ int main ( int argc, char *argv[] ) {
     int width = getParamVal ( "-w",argc,argv,2592 );//define width
     int height =getParamVal ( "-h",argc,argv,1944 );//define height
     cout << "Initializing ..."<<width<<"x"<<height<<endl;
-    Camera.set ( CV_CAP_PROP_FRAME_WIDTH, width );
-    Camera.set ( CV_CAP_PROP_FRAME_HEIGHT, height );
+    Camera.set ( cv::CAP_PROP_FRAME_WIDTH, width );
+    Camera.set ( cv::CAP_PROP_FRAME_HEIGHT, height );
     Camera.open();
     cv::Mat image;
     cout<<"capturing"<<endl;

--- a/utils/raspicam_cv_test.cpp
+++ b/utils/raspicam_cv_test.cpp
@@ -65,19 +65,19 @@ float getParamVal ( string param,int argc,char **argv,float defvalue=-1 ) {
 }
 
 void processCommandLine ( int argc,char **argv,raspicam::RaspiCam_Cv &Camera ) {
-    Camera.set ( CV_CAP_PROP_FRAME_WIDTH,  getParamVal ( "-w",argc,argv,1280 ) );
-    Camera.set ( CV_CAP_PROP_FRAME_HEIGHT, getParamVal ( "-h",argc,argv,960 ) );
-    Camera.set ( CV_CAP_PROP_BRIGHTNESS,getParamVal ( "-br",argc,argv,50 ) );
-    Camera.set ( CV_CAP_PROP_CONTRAST ,getParamVal ( "-co",argc,argv,50 ) );
-    Camera.set ( CV_CAP_PROP_SATURATION, getParamVal ( "-sa",argc,argv,50 ) );
-    Camera.set ( CV_CAP_PROP_GAIN, getParamVal ( "-g",argc,argv ,50 ) );
-    Camera.set ( CV_CAP_PROP_FPS, getParamVal ( "-fps",argc,argv, 0 ) );
+    Camera.set ( cv::CAP_PROP_FRAME_WIDTH,  getParamVal ( "-w",argc,argv,1280 ) );
+    Camera.set ( cv::CAP_PROP_FRAME_HEIGHT, getParamVal ( "-h",argc,argv,960 ) );
+    Camera.set ( cv::CAP_PROP_BRIGHTNESS,getParamVal ( "-br",argc,argv,50 ) );
+    Camera.set ( cv::CAP_PROP_CONTRAST ,getParamVal ( "-co",argc,argv,50 ) );
+    Camera.set ( cv::CAP_PROP_SATURATION, getParamVal ( "-sa",argc,argv,50 ) );
+    Camera.set ( cv::CAP_PROP_GAIN, getParamVal ( "-g",argc,argv ,50 ) );
+    Camera.set ( cv::CAP_PROP_FPS, getParamVal ( "-fps",argc,argv, 0 ) );
     if ( findParam ( "-gr",argc,argv ) !=-1 )
-        Camera.set ( CV_CAP_PROP_FORMAT, CV_8UC1 );
+        Camera.set ( cv::CAP_PROP_FORMAT, CV_8UC1 );
     if ( findParam ( "-test_speed",argc,argv ) !=-1 )
         doTestSpeedOnly=true;
     if ( findParam ( "-ss",argc,argv ) !=-1 )
-        Camera.set ( CV_CAP_PROP_EXPOSURE, getParamVal ( "-ss",argc,argv )  );
+        Camera.set ( cv::CAP_PROP_EXPOSURE, getParamVal ( "-ss",argc,argv )  );
 
 
 //     Camera.setSharpness ( getParamVal ( "-sh",argc,argv,0 ) );


### PR DESCRIPTION
Changed the raspicam files to work with latest builds of OpenCV (tested with OpenCV 4 bleeding edge on raspberry Pi Zero and working without errors). Major changes were made to files `raspicam_cv.cpp` and `raspicam_cv_still.cpp`. Please review and push into master branch if you find them useful.