### PR TITLE
Expose more parameters to Raspicam_cv class.

### DIFF
--- a/src/private/private_impl.h
+++ b/src/private/private_impl.h
@@ -142,8 +142,11 @@ namespace raspicam {
             //sets sensor mode. Can not be changed once camera is opened
             void setSensorMode ( int mode );
 
+            //sets width. Can not be changed once camera is opened
             void setWidth ( unsigned int width ) ;
+            //sets height. Can not be changed once camera is opened
             void setHeight ( unsigned int height );
+            //sets capture size. Can not be changed once camera is opened
             void setCaptureSize ( unsigned int width, unsigned int height );
             void setBrightness ( unsigned int brightness );
             void setRotation ( int rotation );
@@ -166,6 +169,7 @@ namespace raspicam {
               *There is currently an upper limit of approximately 330000us (330ms, 0.33s) past which operation is undefined.
               */
             void setShutterSpeed ( unsigned int shutter ); //currently not  supported
+            //sets frame rate. Can not be changed once camera is opened
             void setFrameRate ( int fps );
 
             RASPICAM_FORMAT  getFormat() const {return State.captureFtm;}

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -195,6 +195,10 @@ namespace raspicam {
 		_impl->setImageEffect ( (RASPICAM_IMAGE_EFFECT)clamped );
 	}
 	
+	void RaspiCam_Cv::setVideoStabilization ( bool enable ) {
+		_impl->setVideoStabilization ( enable );
+	}
+	
     std::string RaspiCam_Cv::getId() const{
         return _impl->getId();
     }

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -180,8 +180,12 @@ namespace raspicam {
             return false;
         };
         return true;
-
     }
+	
+	bool RaspiCam_Cv::setRotation ( int degrees ) {
+		_impl->setRotation ( degrees );
+	}
+	
     std::string RaspiCam_Cv::getId() const{
         return _impl->getId();
     }

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -199,6 +199,14 @@ namespace raspicam {
 		_impl->setVideoStabilization ( enable );
 	}
 	
+	void RaspiCam_Cv::setHorizontalFlip ( bool enable ) {
+		_impl->setHorizontalFlip ( enable );
+	}
+	
+	void RaspiCam_Cv::setVerticalFlip ( bool enable ) {
+		_impl->setVerticalFlip ( enable );
+	}
+	
     std::string RaspiCam_Cv::getId() const{
         return _impl->getId();
     }

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -186,7 +186,7 @@ namespace raspicam {
 		// input is [0;3], map to [0; 360]
 		int clamped = std::max(0, std::min(nRotation, 3));
 		int degrees = clamped * 90;
-		_impl->setRotation ( clamped );
+		_impl->setRotation ( degrees );
 	}
 	
     std::string RaspiCam_Cv::getId() const{

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -186,7 +186,7 @@ namespace raspicam {
 		// input is [0;3], map to [0; 360]
 		int clamped = std::max(0, std::min(nRotation, 3));
 		int degrees = clamped * 90;
-		_impl->setRotation ( degrees );
+		_impl->setRotation ( clamped );
 	}
 	
     std::string RaspiCam_Cv::getId() const{

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -207,6 +207,12 @@ namespace raspicam {
 		_impl->setVerticalFlip ( enable );
 	}
 	
+	void RaspiCam_Cv::setExposureCompensation ( int value ) {
+		// clamp to [-10; 10]
+		int clamped = std::max(-10, std::min(value, 10));
+		_impl->setExposureCompensation ( clamped );
+	}
+	
     std::string RaspiCam_Cv::getId() const{
         return _impl->getId();
     }

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -189,6 +189,12 @@ namespace raspicam {
 		_impl->setRotation ( degrees );
 	}
 	
+	void RaspiCam_Cv::setImageEffect ( int nEffect ) {
+		// Clamp to enum
+		int clamped = std::max(RASPICAM_IMAGE_EFFECT::RASPICAM_IMAGE_EFFECT_NONE, std::min(nEffect, RASPICAM_IMAGE_EFFECT::RASPICAM_IMAGE_EFFECT_CARTOON));
+		_impl->setImageEffect ( clamped );
+	}
+	
     std::string RaspiCam_Cv::getId() const{
         return _impl->getId();
     }

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -191,7 +191,7 @@ namespace raspicam {
 	
 	void RaspiCam_Cv::setImageEffect ( int nEffect ) {
 		// Clamp to enum
-		int clamped = std::max(RASPICAM_IMAGE_EFFECT::RASPICAM_IMAGE_EFFECT_NONE, std::min(nEffect, RASPICAM_IMAGE_EFFECT::RASPICAM_IMAGE_EFFECT_CARTOON));
+		int clamped = std::max((int)RASPICAM_IMAGE_EFFECT::RASPICAM_IMAGE_EFFECT_NONE, std::min(nEffect, (int)RASPICAM_IMAGE_EFFECT::RASPICAM_IMAGE_EFFECT_CARTOON));
 		_impl->setImageEffect ( (RASPICAM_IMAGE_EFFECT)clamped );
 	}
 	

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -192,7 +192,7 @@ namespace raspicam {
 	void RaspiCam_Cv::setImageEffect ( int nEffect ) {
 		// Clamp to enum
 		int clamped = std::max(RASPICAM_IMAGE_EFFECT::RASPICAM_IMAGE_EFFECT_NONE, std::min(nEffect, RASPICAM_IMAGE_EFFECT::RASPICAM_IMAGE_EFFECT_CARTOON));
-		_impl->setImageEffect ( clamped );
+		_impl->setImageEffect ( (RASPICAM_IMAGE_EFFECT)clamped );
 	}
 	
     std::string RaspiCam_Cv::getId() const{

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -213,6 +213,12 @@ namespace raspicam {
 		_impl->setExposureCompensation ( clamped );
 	}
 	
+	void RaspiCam_Cv::setAWB ( int nEnumValue ) {
+		// Clamp to enum
+		int clamped = std::max((int)RASPICAM_AWB::RASPICAM_AWB_OFF, std::min(nEnumValue, (int)RASPICAM_AWB::RASPICAM_AWB_HORIZON));
+		_impl->setAWB ( (RASPICAM_AWB)clamped );
+	}
+	
     std::string RaspiCam_Cv::getId() const{
         return _impl->getId();
     }

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -184,7 +184,8 @@ namespace raspicam {
 	
 	void RaspiCam_Cv::setRotation ( int nRotation ) {
 		// input is [0;3], map to [0; 360]
-		int degrees = std::clamp(nRotation, 0, 3) * 90;
+		int clamped = std::max(0, std::min(nRotation, 3));
+		int degrees = clamped * 90;
 		_impl->setRotation ( degrees );
 	}
 	

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -219,6 +219,12 @@ namespace raspicam {
 		_impl->setAWB ( (RASPICAM_AWB)clamped );
 	}
 	
+	void RaspiCam_Cv::setMetering ( int nEnumValue ) {
+		// Clamp to enum
+		int clamped = std::max((int)RASPICAM_METERING::RASPICAM_METERING_AVERAGE, std::min(nEnumValue, (int)RASPICAM_METERING::RASPICAM_METERING_MATRIX));
+		_impl->setMetering ( (RASPICAM_METERING)clamped );
+	}
+	
     std::string RaspiCam_Cv::getId() const{
         return _impl->getId();
     }

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -182,7 +182,9 @@ namespace raspicam {
         return true;
     }
 	
-	void RaspiCam_Cv::setRotation ( int degrees ) {
+	void RaspiCam_Cv::setRotation ( int nRotation ) {
+		// input is [0;3], map to [0; 360]
+		int degrees = std::clamp(nRotation, 0, 3) * 90;
 		_impl->setRotation ( degrees );
 	}
 	

--- a/src/raspicam_cv.cpp
+++ b/src/raspicam_cv.cpp
@@ -182,7 +182,7 @@ namespace raspicam {
         return true;
     }
 	
-	bool RaspiCam_Cv::setRotation ( int degrees ) {
+	void RaspiCam_Cv::setRotation ( int degrees ) {
 		_impl->setRotation ( degrees );
 	}
 	

--- a/src/raspicam_cv.h
+++ b/src/raspicam_cv.h
@@ -107,7 +107,7 @@ namespace raspicam {
 
         bool set ( int propId, double value );
 		
-        bool setRotation ( int degrees );
+        void setRotation ( int degrees );
 
         /** Returns the camera identifier. We assume the camera id is the one of the raspberry obtained using raspberry serial number obtained in /proc/cpuinfo
          */

--- a/src/raspicam_cv.h
+++ b/src/raspicam_cv.h
@@ -118,6 +118,10 @@ namespace raspicam {
 		/** Sets the image effect. See RASPICAM_IMAGE_EFFECT enum. 19 values as of current implementation.
 		*/
         void setImageEffect ( int nEffect );
+		
+		/** Enable or disable video stabilization
+		*/
+        void setVideoStabilization ( bool enable );
 
         /** Returns the camera identifier. We assume the camera id is the one of the raspberry obtained using raspberry serial number obtained in /proc/cpuinfo
          */

--- a/src/raspicam_cv.h
+++ b/src/raspicam_cv.h
@@ -107,7 +107,13 @@ namespace raspicam {
 
         bool set ( int propId, double value );
 		
-        void setRotation ( int degrees );
+		/** Sets the rotation
+		0: none
+		1: 90 degrees clockwise
+		2: 180 degrees
+		3: 270 degrees clockwise		
+		*/
+        void setRotation ( int nRotation );
 
         /** Returns the camera identifier. We assume the camera id is the one of the raspberry obtained using raspberry serial number obtained in /proc/cpuinfo
          */

--- a/src/raspicam_cv.h
+++ b/src/raspicam_cv.h
@@ -134,6 +134,10 @@ namespace raspicam {
 		/** Set exposure compensation. -10,10
 		*/
 		void setExposureCompensation( int value );
+		
+		/** Sets auto white balance. See RASPICAM_AWB enum. 9 values as of current implementation.
+		*/
+        void setAWB ( int nEnumValue );
 
         /** Returns the camera identifier. We assume the camera id is the one of the raspberry obtained using raspberry serial number obtained in /proc/cpuinfo
          */

--- a/src/raspicam_cv.h
+++ b/src/raspicam_cv.h
@@ -122,6 +122,14 @@ namespace raspicam {
 		/** Enable or disable video stabilization
 		*/
         void setVideoStabilization ( bool enable );
+		
+		/** Enable or disable horizontal flip
+		*/
+		void setHorizontalFlip ( bool enable );
+		
+		/** Enable or disable vertical flip
+		*/
+		void setVerticalFlip ( bool enable );
 
         /** Returns the camera identifier. We assume the camera id is the one of the raspberry obtained using raspberry serial number obtained in /proc/cpuinfo
          */

--- a/src/raspicam_cv.h
+++ b/src/raspicam_cv.h
@@ -106,6 +106,8 @@ namespace raspicam {
          */
 
         bool set ( int propId, double value );
+		
+        bool setRotation ( int degrees );
 
         /** Returns the camera identifier. We assume the camera id is the one of the raspberry obtained using raspberry serial number obtained in /proc/cpuinfo
          */

--- a/src/raspicam_cv.h
+++ b/src/raspicam_cv.h
@@ -138,6 +138,10 @@ namespace raspicam {
 		/** Sets auto white balance. See RASPICAM_AWB enum. 9 values as of current implementation.
 		*/
         void setAWB ( int nEnumValue );
+		
+		/** Sets metering type. See RASPICAM_METERING enum. 4 values as of current implementation.
+		*/
+		void setMetering ( int nEnumValue );
 
         /** Returns the camera identifier. We assume the camera id is the one of the raspberry obtained using raspberry serial number obtained in /proc/cpuinfo
          */

--- a/src/raspicam_cv.h
+++ b/src/raspicam_cv.h
@@ -114,6 +114,10 @@ namespace raspicam {
 		3: 270 degrees clockwise		
 		*/
         void setRotation ( int nRotation );
+		
+		/** Sets the image effect. See RASPICAM_IMAGE_EFFECT enum. 19 values as of current implementation.
+		*/
+        void setImageEffect ( int nEffect );
 
         /** Returns the camera identifier. We assume the camera id is the one of the raspberry obtained using raspberry serial number obtained in /proc/cpuinfo
          */

--- a/src/raspicam_cv.h
+++ b/src/raspicam_cv.h
@@ -130,6 +130,10 @@ namespace raspicam {
 		/** Enable or disable vertical flip
 		*/
 		void setVerticalFlip ( bool enable );
+		
+		/** Set exposure compensation. -10,10
+		*/
+		void setExposureCompensation( int value );
 
         /** Returns the camera identifier. We assume the camera id is the one of the raspberry obtained using raspberry serial number obtained in /proc/cpuinfo
          */


### PR DESCRIPTION
Expose rotation, image effect, video stabilization, horizontal/vertical flip, exposure compensation, auto white balance, and metering in Raspicam_cv class. These parameters are part of the Private_Impl class but were not exposed to the Raspicam_cv class in a convenient way.

*This is my first pull request ever, apologies if I'm doing things wrong*