### PR TITLE
RGBA capture support

### DIFF
--- a/src/private/private_impl.cpp
+++ b/src/private/private_impl.cpp
@@ -216,6 +216,9 @@ namespace raspicam {
             case RASPICAM_FORMAT_RGB:
                 return 3*getWidth() *getHeight();
                 break;
+            case RASPICAM_FORMAT_RGBA:
+                return 4*getWidth()*getHeight();
+                break;
             default:
                 return 0;
             };
@@ -561,6 +564,8 @@ namespace raspicam {
                         int bpp = 1;
                         if(fmt == RASPICAM_FORMAT_RGB || fmt == RASPICAM_FORMAT_BGR) {
                             bpp = 3;
+                        } else if(fmt == RASPICAM_FORMAT_RGBA) {
+                            bpp = 4;
                         }
 
                         for(int i = 0; i < height; i++) {
@@ -878,6 +883,8 @@ namespace raspicam {
 
         int Private_Impl::convertFormat ( RASPICAM_FORMAT fmt ) {
             switch ( fmt ) {
+            case RASPICAM_FORMAT_RGBA:
+                return MMAL_ENCODING_RGBA;
             case RASPICAM_FORMAT_RGB:
                 return _rgb_bgr_fixed ? MMAL_ENCODING_RGB24 : MMAL_ENCODING_BGR24;
             case RASPICAM_FORMAT_BGR:

--- a/src/raspicamtypes.h
+++ b/src/raspicamtypes.h
@@ -47,6 +47,7 @@ namespace raspicam {
         RASPICAM_FORMAT_GRAY,
         RASPICAM_FORMAT_BGR,
         RASPICAM_FORMAT_RGB,
+        RASPICAM_FORMAT_RGBA,
         RASPICAM_FORMAT_IGNORE //do not use
     };
 


### PR DESCRIPTION
Adds support for the RGBA encoding. Useful for usage together with the Broadcom VideoCore JPEG Encoder (brcmjpeg) from RPi Userland.

For example together with this lib:
https://github.com/ideaconnect/raspijpeg/blob/master/raspijpeg.cpp

For example:
```cpp
int main()
{
    raspicam::RaspiCam Camera; //Camera object
    Camera.setWidth(1920);
    Camera.setHeight(1080);
    Camera.setCaptureSize(1920, 1080);
    Camera.setFormat(raspicam::RASPICAM_FORMAT_RGBA);
    Camera.open();
    //waiting 3 secs for camera to settle
    sleep(3);
    //capture
    int bufsize = Camera.getImageTypeSize(Camera.getFormat());
    unsigned char *data = new unsigned char[bufsize];
    Camera.grab();
    Camera.retrieve(data); 
    raspijpeg::jpegdata returndata = raspijpeg::encode(data, bufsize, 1920, 1080, 90, PIXEL_FORMAT_RGBA);
    for (int i = 0; i < returndata.length; i++) {
        cout << returndata.data[i];
    }
}
```

Without __RGBA__ support it would be needed to add the alpha channel to the RGB array using for example:
```
void addalpha(unsigned char* rgba, unsigned char* rgb, const int count) {
    for(int i = 0, rgbai = 0 ;i < count; i=i+3, rgbai = rgbai+4) {
        rgba[rgbai] = rgb[i];
        rgba[rgbai+1] = rgb[i+1];
        rgba[rgbai+2] = rgb[i+2];
        rgba[rgbai+3] = 0;
    }
}
```